### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can tweak this. List of initializions can be found in Materialize documentat
 $('.dropdown-button.main-menu-item').dropdown({
     inDuration: 300,
     outDuration: 225,
-    constrain_width: true, // Does not change width of dropdown to that of the activator
+    constrainWidth: true, // Does not change width of dropdown to that of the activator
     hover: true, // Activate on hover
     belowOrigin: true, // Displays dropdown below the button
     alignment: 'left' // Displays dropdown with edge aligned to the left of button
@@ -72,7 +72,7 @@ $('.dropdown-button.main-menu-item').dropdown({
 $('.dropdown-button.sub-menu-item').dropdown({
     inDuration: 300,
     outDuration: 225,
-    constrain_width: false, // Does not change width of dropdown to that of the activator
+    constrainWidth: false, // Does not change width of dropdown to that of the activator
     hover: true, // Activate on hover
     gutter: ($('.dropdown-content').width() * 3) / 3.05 + 3, // Spacing from edge
     belowOrigin: false, // Displays dropdown below the button


### PR DESCRIPTION
current version of materializecss (beta release v0.100.2, 2017/10/04) uses constrainWidth  instead of constrain_width